### PR TITLE
Added acronym package, changed \acronym newcommand to \IFacronym

### DIFF
--- a/IF-2016-Part_B.tex
+++ b/IF-2016-Part_B.tex
@@ -15,6 +15,7 @@
 \usepackage[usenames,dvipsnames,table]{xcolor}
 \usepackage{csquotes}
 \usepackage{pgfgantt}
+\usepackage[nohyperlinks,nolist]{acronym}
 
 \usepackage[compact]{titlesec}
 % HotFix from http://tex.stackexchange.com/a/300259/84485
@@ -38,7 +39,7 @@
 \renewcommand{\familydefault}{\sfdefault}
 
 \newcommand{\TODO}[1]{{\textcolor{red}{[\textbf{TODO:} #1]}}}
-\newcommand{\acronym}{{\sc Proposal Acronym}\xspace}
+\newcommand{\IFacronym}{{\sc Proposal Acronym}\xspace}
 % \titlespacing\section{0pt}{6pt plus 4pt minus 2pt}{0pt plus 2pt minus 2pt}
 % \titlespacing\subsection{0pt}{6pt plus 4pt minus 2pt}{0pt plus 2pt minus 2pt}
 % \titlespacing\subsubsection{0pt}{6pt plus 4pt minus 2pt}{0pt plus 2pt minus 2pt}
@@ -131,7 +132,12 @@
 }
 \makeatother
 
-
+%List of acronyms used in the proposal 
+%read the acronym package manual for details
+\begin{acronym}
+\acro{IF}{Individual Fellowship}
+\acro{tima}[TIMA]{This is my acronym}
+\end{acronym}
 
 \begin{document}
 %\begin{linenumbers}

--- a/doc1.tex
+++ b/doc1.tex
@@ -16,14 +16,14 @@
           MARIE SK\L{}ODOWSKA-CURIE ACTIONS\\
           \vspace{1cm}
           
-          \textbf{Individual Fellowships (IF)}\\
+          \textbf{\acf{IF}}\\
           \textbf{Call: H2020-MSCA-IF-2016}
           \vspace{2cm}                   
 
           PART B
           \vspace{2.5cm}
 
-          ``\acronym''
+          ``\IFacronym''
           \vspace{2cm}
 
           \textbf{This proposal is to be evaluated as:}

--- a/doc2.tex
+++ b/doc2.tex
@@ -234,14 +234,14 @@ Please note that proposals failing to comply with the above-mentioned requiremen
           MARIE SK\L{}ODOWSKA-CURIE ACTIONS\\
           \vspace{1cm}
           
-          \textbf{Individual Fellowships (IF)}\\
+          \textbf{\acf{IF}}\\
           \textbf{Call: H2020-MSCA-IF-2016}
           \vspace{2cm}                   
 
           PART B
           \vspace{2.5cm}
 
-          ``\acronym''
+          ``\IFacronym''
           \vspace{2cm}
 
           \textbf{This proposal is to be evaluated as:}


### PR DESCRIPTION
The acronym package is quite useful in this context, keeping track automatically of all used acronyms and making sure they are used in the right (long/short) form.

Then I renamed \acronym to \IFacronym to avoid the name clash

(hope I'm doing the correct pull request this time. Not so experienced about it yet)
